### PR TITLE
try to fix post request with form/data.

### DIFF
--- a/middleware/gingonic/gin-gonic.go
+++ b/middleware/gingonic/gin-gonic.go
@@ -137,9 +137,7 @@ func parseRequestBody(c *gin.Context, limit uint) (string, error) {
 			c.Request.URL.Path, err)
 	}
 	// resume request body
-	if c.Request.Body == nil {
-		c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-	}
+	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 	// deal unicode char in body
 	br := []rune(string(b[:]))
 	body.WriteString(limitBeautyBody(br, limit))


### PR DESCRIPTION
Fix a bug in gin-gonic middleware. 

When logger middleware handle post request with Content-Type 'form/data', the request body can't be resumed normally.